### PR TITLE
Gracefully destroy team membership

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -46,11 +46,11 @@ func resourcePagerDutyTeamMembership() *schema.Resource {
 }
 
 func maxRetries() int {
-	return 4
+	return 10
 }
 
 func retryDelayMs() int {
-	return 500
+	return 5000
 }
 
 func calculateDelay(retryCount int) time.Duration {
@@ -61,7 +61,6 @@ func fetchPagerDutyTeamMembershipWithRetries(d *schema.ResourceData, meta interf
 	if retryCount >= maxRetries() {
 		return nil
 	}
-
 	if err := fetchPagerDutyTeamMembership(d, meta, errCallback); err != nil {
 		return err
 	}
@@ -140,6 +139,7 @@ func resourcePagerDutyTeamMembershipCreate(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", userID, teamID))
+
 	return fetchPagerDutyTeamMembershipWithRetries(d, meta, genError, 0, d.Get("role").(string))
 }
 

--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -161,8 +161,7 @@ func TestAccPagerDutyTeamMembership_DestroyWithUsersAndEscalationPolicyDependant
 				Config: testAccCheckPagerDutyTeamMembershipDestroyWithUsersAndEscalationPolicyDependantUpdated(user, team, role, escalationPolicy, user2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyTeamMembershipNoExists("pagerduty_team_membership.bar"),
-					testAccCheckPagerDutyUserNoExists("pagerduty_user.bar"),
-					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
+					testAccCheckPagerDutyUserNoExists("pagerduty_user.foo"),
 				),
 			},
 		},

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -152,6 +152,7 @@ func testAccCheckPagerDutyTeamExists(n string) resource.TestCheckFunc {
 
 func testAccCheckPagerDutyTeamConfig(team string) string {
 	return fmt.Sprintf(`
+
 resource "pagerduty_team" "foo" {
   name        = "%s"
   description = "foo"

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -134,11 +134,17 @@ func testAccCheckPagerDutyTeamDestroy(s *terraform.State) error {
 
 func testAccCheckPagerDutyTeamExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Team not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No team ID is set")
+		}
+
 		client, _ := testAccProvider.Meta().(*Config).Client()
-		for _, r := range s.RootModule().Resources {
-			if _, _, err := client.Teams.Get(r.Primary.ID); err != nil {
-				return fmt.Errorf("Received an error retrieving team %s ID: %s", err, r.Primary.ID)
-			}
+		if _, _, err := client.Teams.Get(rs.Primary.ID); err != nil {
+			return fmt.Errorf("Received an error retrieving team %s ID: %s", err, rs.Primary.ID)
 		}
 		return nil
 	}
@@ -146,7 +152,6 @@ func testAccCheckPagerDutyTeamExists(n string) resource.TestCheckFunc {
 
 func testAccCheckPagerDutyTeamConfig(team string) string {
 	return fmt.Sprintf(`
-
 resource "pagerduty_team" "foo" {
   name        = "%s"
   description = "foo"

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -275,6 +275,7 @@ func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[ERROR] Deleting PagerDuty user %s", d.Id())
 		return err
 	}
+
 	log.Printf("[INFO] Deleting PagerDuty user %s %s", d.Id(), d.Get("email"))
 
 	// Retrying to give other resources (such as escalation policies) to delete

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -272,21 +272,17 @@ func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error
 func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error {
 	client, err := meta.(*Config).Client()
 	if err != nil {
-		log.Printf("[ERROR] Deleting PagerDuty user %s", d.Id())
 		return err
 	}
 
-	log.Printf("[INFO] Deleting PagerDuty user %s %s", d.Id(), d.Get("email"))
+	log.Printf("[INFO] Deleting PagerDuty user %s", d.Id())
 
 	// Retrying to give other resources (such as escalation policies) to delete
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Users.Delete(d.Id()); err != nil {
 			if isErrCode(err, 400) {
-				log.Printf("[ERROR IGNORED] Retrying Deleting PagerDuty user %s", d.Id())
-
 				return resource.RetryableError(err)
 			}
-			log.Printf("[ERROR] Retrying Deleting PagerDuty user %s", d.Id())
 
 			return resource.NonRetryableError(err)
 		}
@@ -298,7 +294,6 @@ func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId("")
-	log.Printf("[INFO] Deleted PagerDuty user %s", d.Id())
 
 	// giving the API time to catchup
 	time.Sleep(time.Second)

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -41,7 +41,7 @@ func testSweepUser(region string) error {
 	}
 
 	for _, user := range resp.Users {
-		if strings.HasPrefix(user.Name, "tf") {
+		if strings.HasPrefix(user.Name, "test") || strings.HasPrefix(user.Name, "tf") {
 			log.Printf("Destroying user %s (%s)", user.Name, user.ID)
 			if _, err := client.Users.Delete(user.ID); err != nil {
 				return err
@@ -159,7 +159,7 @@ func testAccCheckPagerDutyUserDestroy(s *terraform.State) error {
 		}
 
 		if _, _, err := client.Users.Get(r.Primary.ID, &pagerduty.GetUserOptions{}); err == nil {
-			return fmt.Errorf("User still exists %s", r.Primary.ID)
+			return fmt.Errorf("User still exists")
 		}
 
 	}

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -41,7 +41,7 @@ func testSweepUser(region string) error {
 	}
 
 	for _, user := range resp.Users {
-		if strings.HasPrefix(user.Name, "test") || strings.HasPrefix(user.Name, "tf") {
+		if strings.HasPrefix(user.Name, "tf") {
 			log.Printf("Destroying user %s (%s)", user.Name, user.ID)
 			if _, err := client.Users.Delete(user.ID); err != nil {
 				return err
@@ -159,7 +159,7 @@ func testAccCheckPagerDutyUserDestroy(s *terraform.State) error {
 		}
 
 		if _, _, err := client.Users.Get(r.Primary.ID, &pagerduty.GetUserOptions{}); err == nil {
-			return fmt.Errorf("User still exists")
+			return fmt.Errorf("User still exists %s", r.Primary.ID)
 		}
 
 	}
@@ -187,6 +187,16 @@ func testAccCheckPagerDutyUserExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("User not found: %v - %v", rs.Primary.ID, found)
 		}
 
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyUserNoExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, _ := testAccProvider.Meta().(*Config).Client()
+		if _, _, err := client.Users.Get(n, &pagerduty.GetUserOptions{}); err == nil {
+			return fmt.Errorf("User still exists %s", n)
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
```
make testacc TESTARGS="-run TestAccPagerDutyUser"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyUser -timeout 120m
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
=== RUN   TestAccPagerDutyUserContactMethod_import
--- PASS: TestAccPagerDutyUserContactMethod_import (16.95s)
=== RUN   TestAccPagerDutyUserNotificationRule_import
--- PASS: TestAccPagerDutyUserNotificationRule_import (20.98s)
=== RUN   TestAccPagerDutyUser_import
--- PASS: TestAccPagerDutyUser_import (12.88s)
=== RUN   TestAccPagerDutyUserContactMethodEmail_Basic
--- PASS: TestAccPagerDutyUserContactMethodEmail_Basic (26.06s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_Basic
--- PASS: TestAccPagerDutyUserContactMethodPhone_Basic (28.80s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist
--- PASS: TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist (30.00s)
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- PASS: TestAccPagerDutyUserContactMethodSMS_Basic (25.95s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Basic
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Basic (40.04s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Invalid
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Invalid (10.57s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id (8.25s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type (10.67s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key (11.10s)
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (18.85s)
=== RUN   TestAccPagerDutyUserWithTeams_Basic
--- PASS: TestAccPagerDutyUserWithTeams_Basic (33.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	295.003s
```

```
make testacc TESTARGS="-run TestAccPagerDutyTeamMembership"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyTeamMembership -timeout 120m
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
=== RUN   TestAccPagerDutyTeamMembership_import
--- PASS: TestAccPagerDutyTeamMembership_import (17.52s)
=== RUN   TestAccPagerDutyTeamMembership_importWithRole
--- PASS: TestAccPagerDutyTeamMembership_importWithRole (17.22s)
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (18.40s)
=== RUN   TestAccPagerDutyTeamMembership_WithRole
--- PASS: TestAccPagerDutyTeamMembership_WithRole (16.97s)
=== RUN   TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned
--- PASS: TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned (29.84s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant (26.96s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyAllButKeepOneUser
--- PASS: TestAccPagerDutyTeamMembership_DestroyAllButKeepOneUser (37.01s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithUserAndEscalationPolicyDependant
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithUserAndEscalationPolicyDependant (26.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	190.243s
```